### PR TITLE
Upgrade trunk (#14)

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -44,8 +44,8 @@ lint:
     - black@23.7.0
     - buf-lint@1.25.0
     - buildifier@6.1.2
-    - cfnlint@0.78.2
-    - checkov@2.3.335
+    - cfnlint@0.79.4
+    - checkov@2.3.347
     - clang-format@16.0.3
     - clang-tidy@16.0.3
     - clippy@1.65.0
@@ -62,22 +62,22 @@ lint:
     - oxipng@8.0.0
     - pragma-once
     - prettier@3.0.0
-    - pylint@2.17.4
-    - renovate@36.18.4
+    - pylint@2.17.5
+    - renovate@36.25.0
     - rubocop@1.39.0
-    - ruff@0.0.279
+    - ruff@0.0.280
     - rustfmt@1.68.2
-    - semgrep@1.33.1
+    - semgrep@1.34.0
     - shellcheck@0.9.0
     - shfmt@3.6.0
     - sort-package-json@2.5.1
-    - sql-formatter@12.2.3
+    - sql-formatter@12.2.4
     - stylelint@15.10.2
     - svgo@3.0.2
     - taplo@0.8.1
-    - terrascan@1.18.1
+    - terrascan@1.18.2
     - trivy@0.43.1
-    - trufflehog@3.44.0
+    - trufflehog@3.45.2
     - trunk-toolbox@0.0.0-pat.19
     - yamllint@1.32.0
 


### PR DESCRIPTION
[![Trunk](https://static.trunk.io/assets/trunk_action_upgrade_banner.png)](https://trunk.io)

9 linters were upgraded:

- cfnlint 0.78.2 → 0.79.4
- checkov 2.3.335 → 2.3.347
- pylint 2.17.4 → 2.17.5
- renovate 36.18.4 → 36.25.0
- ruff 0.0.279 → 0.0.280
- semgrep 1.33.1 → 1.34.0
- sql-formatter 12.2.3 → 12.2.4
- terrascan 1.18.1 → 1.18.2
- trufflehog 3.44.0 → 3.45.2

This PR was generated by the [Trunk Action]. For more info, see our [docs] or reach out on [Slack].

[Trunk Action]: https://github.com/trunk-io/trunk-action
[docs]: https://docs.trunk.io
[Slack]: https://slack.trunk.io/